### PR TITLE
Fix installation exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup(
     provides=modules,
     scripts=scripts,
     include_package_data=True,
-    description=__doc__,
+    description=__doc__.rstrip(),
     long_description=open(readme, "r").read(),
     keywords=KEYWORDS,
     download_url=PACKAGE_DOWNLOAD_URL,


### PR DESCRIPTION
An exception ocurred while installing using ``pip install -e git+https://github.com/Nekmo/django-rest-framework-security.git@develop#egg=django-rest-framework-security``

```python
Obtaining django-rest-framework-security from git+https://github.com/Nekmo/django-rest-framework-security.git@develop#egg=django-rest-framework-security
  Updating /home/<user>/.env/<project>/src/django-rest-framework-security clone (to revision develop)
  Running command git fetch -q --tags
  Running command git reset --hard -q 1f0e3bba4d4c8c71dd51ab8334ea640f31a426c0
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build wheel ... error
  ERROR: Command errored out with exit status 1:
   command: /home/<user>/.env/<project>/bin/python /home/<user>/.env/<project>/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmpr0zkcfv1
       cwd: /home/<user>/.env/<project>/src/django-rest-framework-security
  Complete output (38 lines):
  running egg_info
  writing django_rest_framework_security.egg-info/PKG-INFO
  Traceback (most recent call last):
    File "/home/<user>/.env/<project>/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
      main()
    File "/home/<user>/.env/<project>/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/home/<user>/.env/<project>/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 130, in get_requires_for_build_wheel
      return hook(config_settings)
    File "/tmp/pip-build-env-_vsbhq8b/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 162, in get_requires_for_build_wheel
      return self._get_build_requires(
    File "/tmp/pip-build-env-_vsbhq8b/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 143, in _get_build_requires
      self.run_setup()
    File "/tmp/pip-build-env-_vsbhq8b/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 267, in run_setup
      super(_BuildMetaLegacyBackend,
    File "/tmp/pip-build-env-_vsbhq8b/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 158, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 148, in <module>
      setup(
    File "/tmp/pip-build-env-_vsbhq8b/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 153, in setup
      return distutils.core.setup(**attrs)
    File "/usr/lib/python3.9/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/lib/python3.9/distutils/dist.py", line 966, in run_commands
      self.run_command(cmd)
    File "/usr/lib/python3.9/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/tmp/pip-build-env-_vsbhq8b/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 292, in run
      writer(self, ep.name, os.path.join(self.egg_info, ep.name))
    File "/tmp/pip-build-env-_vsbhq8b/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 656, in write_pkg_info
      metadata.write_pkg_info(cmd.egg_info)
    File "/usr/lib/python3.9/distutils/dist.py", line 1117, in write_pkg_info
      self.write_pkg_file(pkg_info)
    File "/tmp/pip-build-env-_vsbhq8b/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 167, in write_pkg_file
      write_field('Summary', single_line(self.get_description()))
    File "/tmp/pip-build-env-_vsbhq8b/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 151, in single_line
      raise ValueError('Newlines are not allowed')
  ValueError: Newlines are not allowed
  ----------------------------------------
WARNING: Discarding git+https://github.com/Nekmo/django-rest-framework-security.git@develop#egg=django-rest-framework-security. Command errored out with exit status 1: /home/<user>/.env/<project>/bin/python /home/<user>/.env/<project>/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmpr0zkcfv1 Check the logs for full command output.
ERROR: Could not find a version that satisfies the requirement django-rest-framework-security (unavailable) (from versions: none)
ERROR: No matching distribution found for django-rest-framework-security (unavailable)
```